### PR TITLE
Fix encoding issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
       <version>3.0.22</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>

--- a/src/main/java/it/ethiclab/dotnet/VersionMojo.java
+++ b/src/main/java/it/ethiclab/dotnet/VersionMojo.java
@@ -1,21 +1,18 @@
 package it.ethiclab.dotnet;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
-import java.nio.charset.Charset;
-import java.nio.file.Paths;
-import java.util.List;
-
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.List;
 
 @Mojo(name = "version")
 public class VersionMojo extends AbstractMojo {
@@ -91,7 +88,7 @@ public class VersionMojo extends AbstractMojo {
 			}
     		
     	} finally {
-    		log.info("DEFAULT CHARSET = " + Charset.defaultCharset().name());
+    		log.info("SOURCE CHARSET = " + getSourceEncoding());
     		log.info("VERSION END");
     	}
     }
@@ -166,11 +163,21 @@ public class VersionMojo extends AbstractMojo {
 	}
 
 	private void changeVersion(File f, File backup) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(backup)));
-		PrintWriter pw = new PrintWriter(f, project.getProperties().getProperty("project.build.sourceEncoding", Charset.defaultCharset().name()));
+		BOMInputStream is = new BOMInputStream(new FileInputStream(backup));
+		BufferedReader br = new BufferedReader(new InputStreamReader(is, getSourceEncoding()));
+		OutputStream os = new FileOutputStream(f);
+		PrintWriter pw = new PrintWriter(
+				new BufferedWriter(
+						new OutputStreamWriter(os, getSourceEncoding())
+				)
+		);
 		try
 		{
 			String line = null;
+			ByteOrderMark bom = is.getBOM();
+			if (bom != null) {
+				os.write(bom.getBytes());
+			}
 			do {
 				line = br.readLine();
 				if (line != null) {
@@ -203,8 +210,12 @@ public class VersionMojo extends AbstractMojo {
 		}
 	}
 
+	private String getSourceEncoding() {
+		return project.getProperties().getProperty("project.build.sourceEncoding", Charset.defaultCharset().name());
+	}
+
 	private boolean hasAssemblyVersionInfo(File f) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(f)));
+		BufferedReader br = new BufferedReader(new InputStreamReader(new BOMInputStream(new FileInputStream(f)), getSourceEncoding()));
 		try
 		{
 			String line = null;


### PR DESCRIPTION
The version goal screws up the encoding of the processed cs files.

This patch makes sure the same encoding is used when reading _and_ writing the cs files.
It also handles the BOM correctly if it is present at the beginning of the file.